### PR TITLE
Add Retail Liquidity Indicator Message

### DIFF
--- a/IEXTools/IEXparser.py
+++ b/IEXTools/IEXparser.py
@@ -99,6 +99,7 @@ class Parser(object):
             messages.SystemEvent: b"\x53",
             messages.SecurityDirective: b"\x44",
             messages.TradingStatus: b"\x48",
+            messages.RetailLiquidity: b"\x49",
             messages.OperationalHalt: b"\x4f",
             messages.QuoteUpdate: b"\x51",
         }

--- a/IEXTools/TypeAliases.py
+++ b/IEXTools/TypeAliases.py
@@ -10,6 +10,7 @@ AllMessages = Union[
     messages.SystemEvent,
     messages.SecurityDirective,
     messages.TradingStatus,
+    messages.RetailLiquidity,
     messages.OperationalHalt,
     messages.QuoteUpdate,
 ]

--- a/IEXTools/messages.py
+++ b/IEXTools/messages.py
@@ -64,6 +64,11 @@ class MessageDecoder(object):
                     "cls": TradingStatus,
                     "fmt": "<1sq8s4s",
                 },
+                b"\x49": {
+                    "str": "Retail Liquidity Indicator Message",
+                    "cls": RetailLiquidity,
+                    "fmt": "<1sq8s",
+                },
                 b"\x4f": {
                     "str": "Operational Halt Status Message",
                     "cls": OperationalHalt,
@@ -241,6 +246,20 @@ class TradingStatus(Message):
         Message.__post_init__(self)
         self.trading_status_message = trading_status_messages[self.status]
 
+@dataclass
+class RetailLiquidity(Message):
+    """
+    From the TOPS specification document: "TOPS broadcasts a real-time Retail Liquidity
+    Indicator Message each time there is an update to IEX's eligible retail 
+    liquidity interest during the trading day. Prior to the start of trading, IEX publishes
+    a "no interest indicator" (Retail Liquidity Indicator is set to '0x20') for all
+    symbols in the IEX Trading System.
+    """
+
+    __slots__ = ("retail_liquidity_indicator", "timestamp", "symbol")
+    retail_liquidity_indicator: str  # 1 byte
+    timestamp: int  # 8 bytes
+    symbol: str  # 8 bytes
 
 @dataclass
 class OperationalHalt(Message):
@@ -424,6 +443,7 @@ AllMessages = Union[
     SystemEvent,
     SecurityDirective,
     TradingStatus,
+    RetailLiquidity,
     OperationalHalt,
     QuoteUpdate,
 ]


### PR DESCRIPTION
Added support to the new message they added as of October 2021. I ran tests against pcap files after the fact so it should world.